### PR TITLE
CORE-8886 Add `pids_limit` field to docker-compose.yml job files.

### DIFF
--- a/dcompose/dcompose.go
+++ b/dcompose/dcompose.go
@@ -100,6 +100,7 @@ type Service struct {
 	MemSwappiness string                           `yaml:"mem_swappiness,omitempty"`
 	NetworkMode   string                           `yaml:"network_mode,omitempty"`
 	Networks      map[string]*ServiceNetworkConfig `yaml:",omitempty"`
+	PIDsLimit     int64                            `yaml:"pids_limit,omitempty"`
 	Ports         []string                         `yaml:",omitempty"`
 	Volumes       []string                         `yaml:",omitempty"`
 	VolumesFrom   []string                         `yaml:"volumes_from,omitempty"`
@@ -129,7 +130,7 @@ func New(ld string, pathprefix string) (*JobCompose, error) {
 	}
 
 	return &JobCompose{
-		Version:  "2",
+		Version:  "2.1",
 		Volumes:  make(map[string]*Volume),
 		Networks: make(map[string]*Network),
 		Services: make(map[string]*Service),
@@ -285,6 +286,10 @@ func (j *JobCompose) ConvertStep(step *model.Step, index int, user, invID string
 
 	if stepContainer.CPUShares > 0 {
 		svc.CPUShares = stepContainer.CPUShares
+	}
+
+	if stepContainer.PIDsLimit > 0 {
+		svc.PIDsLimit = stepContainer.PIDsLimit
 	}
 
 	if stepContainer.NetworkMode != "" {

--- a/dcompose/dcompose_test.go
+++ b/dcompose/dcompose_test.go
@@ -65,6 +65,7 @@ var testJob = &model.Job{
 					ID:        "container-id-1",
 					Name:      "container-name-1",
 					CPUShares: 0,
+					PIDsLimit: 64,
 					Image: model.ContainerImage{
 						ID:   "container-image-1",
 						Name: "container-image-name-1",
@@ -353,22 +354,28 @@ func TestConvertStep(t *testing.T) {
 	if _, ok := jc.Services["step_0"]; !ok {
 		t.Error("step_0 not found")
 	}
-	if _, ok := jc.Services["step_0"].Environment["FOO"]; !ok {
+
+	svc := jc.Services["step_0"]
+
+	if _, ok := svc.Environment["FOO"]; !ok {
 		t.Error("environment var FOO not found")
 	}
-	if jc.Services["step_0"].Environment["FOO"] != "BAR" {
-		t.Errorf("FOO value was %s instead of 'BAR'", jc.Services["step_0"].Environment["FOO"])
+	if svc.Environment["FOO"] != "BAR" {
+		t.Errorf("FOO value was %s instead of 'BAR'", svc.Environment["FOO"])
 	}
-	if _, ok := jc.Services["step_0"].Environment["BAZ"]; !ok {
+	if _, ok := svc.Environment["BAZ"]; !ok {
 		t.Error("environment var BAZ not found")
 	}
-	if jc.Services["step_0"].Environment["BAZ"] != "1" {
-		t.Errorf("BAZ value was %s instead of '1'", jc.Services["step_0"].Environment["BAZ"])
+	if svc.Environment["BAZ"] != "1" {
+		t.Errorf("BAZ value was %s instead of '1'", svc.Environment["BAZ"])
 	}
-	svc := jc.Services["step_0"]
 	if svc.Image != "container-image-name-1:container-image-tag-1" {
 		t.Errorf("image was %s", svc.Image)
 	}
+	if svc.PIDsLimit != 64 {
+		t.Errorf("PIDsLimit was %d, expecting 64", svc.PIDsLimit)
+	}
+
 	if !reflect.DeepEqual(svc.Command, []string{"step-param-name-1", "step-param-value-1", "step-param-name-2", "step-param-value-2"}) {
 		t.Errorf("command was %#v", svc.Command)
 	}

--- a/vendor/gopkg.in/cyverse-de/model.v1/container.go
+++ b/vendor/gopkg.in/cyverse-de/model.v1/container.go
@@ -49,6 +49,7 @@ type Container struct {
 	MinMemoryLimit int64          `json:"min_memory_limit"` // The minimum the container needs.
 	MinCPUCores    int            `json:"min_cpu_cores"`    // The minimum number of cores the container needs.
 	MinDiskSpace   int64          `json:"min_disk_space"`   // The minimum amount of disk space that the container needs.
+	PIDsLimit      int64          `json:"pids_limit"`
 	Image          ContainerImage `json:"image"`
 	EntryPoint     string         `json:"entrypoint"`
 	WorkingDir     string         `json:"working_directory"`

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -562,7 +562,7 @@
 			"importpath": "gopkg.in/cyverse-de/model.v1",
 			"repository": "https://gopkg.in/cyverse-de/model.v1",
 			"vcs": "git",
-			"revision": "bf8453314372d00979c0cdf7da069515acdbb6be",
+			"revision": "3b06c9e9e248fcd8bcb1b660b3047908cb91c1ba",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
This PR will update `ConvertStep` to save the job model's new `PIDsLimit` field (see cyverse-de/model#6) to the `PIDsLimit` field of a docker-compose `Service` struct.