### PR TITLE
CORE-9164 Allow non-root users to create job outputs.

### DIFF
--- a/run.go
+++ b/run.go
@@ -84,6 +84,13 @@ func (r *JobRunner) Init() error {
 		return err
 	}
 
+	// Set world-write perms on volumeDir, so non-root users can create job outputs.
+	err = os.Chmod(r.volumeDir, 0777)
+	if err != nil {
+		// Log error and continue.
+		log.Error(err)
+	}
+
 	// Copy docker-compose file to the log dir for debugging purposes.
 	err = fs.CopyFile(fs.FS, "docker-compose.yml", path.Join(r.logsDir, "docker-compose.yml"))
 	if err != nil {


### PR DESCRIPTION
Updated `run.go` to set 777 permissions on the tool's working directory.

Updated `dcompose.go` to mount that directory directly into the container instead of creating a volume for this working dir, since mounting the volume resets the ownership and permissions of the host directory to root and 755.