### PR TITLE
Change the way data containers are named to limit conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.7
 
+RUN go get github.com/jstemmer/go-junit-report
+
 COPY . /go/src/github.com/cyverse-de/road-runner
 RUN go install github.com/cyverse-de/road-runner
 

--- a/dcompose/dcompose.go
+++ b/dcompose/dcompose.go
@@ -153,7 +153,7 @@ func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir st
 		svcKey := fmt.Sprintf("data_%d", index)
 		j.Services[svcKey] = &Service{
 			Image:         fmt.Sprintf("%s:%s", dc.Name, dc.Tag),
-			ContainerName: fmt.Sprintf("%s-%s", dc.NamePrefix, job.InvocationID),
+			ContainerName: fmt.Sprintf("%s_%d_%s", dc.NamePrefix, index, job.InvocationID),
 			EntryPoint:    "/bin/true",
 			Logging:       &LoggingConfig{Driver: "none"},
 			Labels: map[string]string{

--- a/dcompose/dcompose.go
+++ b/dcompose/dcompose.go
@@ -149,32 +149,6 @@ func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir st
 	porklockTag := cfg.GetString("porklock.tag")
 	porklockImageName := fmt.Sprintf("%s:%s", porklockImage, porklockTag)
 
-	for index, dc := range job.DataContainers() {
-		svcKey := fmt.Sprintf("data_%d", index)
-		j.Services[svcKey] = &Service{
-			Image:         fmt.Sprintf("%s:%s", dc.Name, dc.Tag),
-			ContainerName: fmt.Sprintf("%s_%d_%s", dc.NamePrefix, index, job.InvocationID),
-			EntryPoint:    "/bin/true",
-			Logging:       &LoggingConfig{Driver: "none"},
-			Labels: map[string]string{
-				model.DockerLabelKey: strconv.Itoa(DataContainer),
-			},
-		}
-
-		svc := j.Services[svcKey]
-		if dc.HostPath != "" || dc.ContainerPath != "" {
-			var rw string
-			if dc.ReadOnly {
-				rw = "ro"
-			} else {
-				rw = "rw"
-			}
-			svc.Volumes = []string{
-				fmt.Sprintf("%s:%s:%s", dc.HostPath, dc.ContainerPath, rw),
-			}
-		}
-	}
-
 	for index, input := range job.Inputs() {
 		j.Services[fmt.Sprintf("input_%d", index)] = &Service{
 			CapAdd:  []string{"IPC_LOCK"},
@@ -225,8 +199,38 @@ func (j *JobCompose) InitFromJob(job *model.Job, cfg *viper.Viper, workingdir st
 	}
 }
 
+// ConvertDataContainer will add the data container to the JobCompose services and returns the service name for it
+func (j *JobCompose) ConvertDataContainer(dc model.VolumesFrom, stepIndex, dataContainerIndex int, invID string) string {
+	svcKey := fmt.Sprintf("data_%d_%d", stepIndex, dataContainerIndex)
+	j.Services[svcKey] = &Service{
+		Image:         fmt.Sprintf("%s:%s", dc.Name, dc.Tag),
+		ContainerName: fmt.Sprintf("%s_%d_%d_%s", dc.NamePrefix, stepIndex, dataContainerIndex, invID),
+		EntryPoint:    "/bin/true",
+		Logging:       &LoggingConfig{Driver: "none"},
+		Labels: map[string]string{
+			model.DockerLabelKey: strconv.Itoa(DataContainer),
+		},
+	}
+
+	svc := j.Services[svcKey]
+	if dc.HostPath != "" || dc.ContainerPath != "" {
+		var rw string
+		if dc.ReadOnly {
+			rw = "ro"
+		} else {
+			rw = "rw"
+		}
+		svc.Volumes = []string{
+			fmt.Sprintf("%s:%s:%s", dc.HostPath, dc.ContainerPath, rw),
+		}
+	}
+
+	return svcKey
+}
+
 // ConvertStep will add the job step to the JobCompose services
 func (j *JobCompose) ConvertStep(step *model.Step, index int, user, invID, workingDirHostPath string) {
+
 	// Construct the name of the image
 	// Set the name of the image for the container.
 	var imageName string
@@ -295,15 +299,11 @@ func (j *JobCompose) ConvertStep(step *model.Step, index int, user, invID, worki
 	}
 
 	// Handles volumes created by other containers.
-	for _, vf := range stepContainer.VolumesFrom {
-		containerName := fmt.Sprintf("%s-%s", vf.NamePrefix, invID)
-		var foundService string
-		for svckey, svc := range j.Services { // svckey is the docker-compose service name.
-			if svc.ContainerName == containerName {
-				foundService = svckey
-			}
-		}
-		svc.VolumesFrom = append(svc.VolumesFrom, foundService)
+	for dcIndex, dc := range stepContainer.VolumesFrom {
+		// create data container
+		svckey := j.ConvertDataContainer(dc, index, dcIndex, invID)
+
+		svc.VolumesFrom = append(svc.VolumesFrom, svckey)
 	}
 
 	// The working directory needs to be mounted as a volume.

--- a/dcompose/dcompose_test.go
+++ b/dcompose/dcompose_test.go
@@ -347,7 +347,7 @@ func TestConvertStep(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	jc.ConvertStep(&testJob.Steps[0], 0, testJob.Submitter, testJob.InvocationID)
+	jc.ConvertStep(&testJob.Steps[0], 0, testJob.Submitter, testJob.InvocationID, "")
 	if len(jc.Services) != 1 {
 		t.Errorf("number of services was %d and not 1", len(jc.Services))
 	}


### PR DESCRIPTION
Include the index of the data container so that two data containers in
the same job with the same NamePrefix (e.g., in a workflow where
multiple steps use the same tool) don't try to create with the exact
same name.