### PR TITLE
CORE-9219 Set 777 permissions on job's temp directory.

### DIFF
--- a/run.go
+++ b/run.go
@@ -91,6 +91,13 @@ func (r *JobRunner) Init() error {
 		log.Error(err)
 	}
 
+	// Set world-write perms on tmpDir, so non-root users can create temp outputs.
+	err = os.Chmod(r.tmpDir, 0777)
+	if err != nil {
+		// Log error and continue.
+		log.Error(err)
+	}
+
 	// Copy docker-compose file to the log dir for debugging purposes.
 	err = fs.CopyFile(fs.FS, "docker-compose.yml", path.Join(r.logsDir, "docker-compose.yml"))
 	if err != nil {


### PR DESCRIPTION
This PR will set 777 permissions on every job's temp directory.

Some tool containers want to run as a user other than root. Giving the job's temp directory 777 permissions means the mounted `/tmp` directory in the tool's container will also get 777 permissions.

