### PR TITLE
CORE-9192 Update JobCompose and JobRunner with Input Path List support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -147,8 +147,8 @@
 [[projects]]
   name = "gopkg.in/cyverse-de/model.v2"
   packages = ["."]
-  revision = "4aff5a8d5de9eb2eeb6b1e9c19dbc443c5e8b347"
-  version = "v2.10"
+  revision = "b6fae6c0f89c0d1ee641eef0016db8d54ee3ca7a"
+  version = "v2.11"
 
 [[projects]]
   branch = "v2"
@@ -159,6 +159,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4b75d082a776ce0b4ad7510bd201c3b5eb9e1d9d6d52b7320bccc3257bec7446"
+  inputs-digest = "2b05889b3fed964ecd0fb2a0ca83eaa57440356066a39d7f82990cba2e92c9b6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@
 
 [[constraint]]
   name = "gopkg.in/cyverse-de/model.v2"
-  version = "2.0.0"
+  version = "2.11.0"
 
 [[constraint]]
   branch = "v2"

--- a/vendor/gopkg.in/cyverse-de/model.v2/io.go
+++ b/vendor/gopkg.in/cyverse-de/model.v2/io.go
@@ -63,17 +63,33 @@ func (i *StepInput) Source() string {
 	return value
 }
 
+// Returns the porklock settings needed for a get command with an input path list.
+func (j *Job) InputSourceListArguments(sourceListPath string) []string {
+	args := []string{
+		"get",
+		"--user", j.Submitter,
+		"--source-list", sourceListPath,
+	}
+
+	for _, m := range MetadataArgs(j.FileMetadata).FileMetadataArguments() {
+		args = append(args, m)
+	}
+
+	return args
+}
+
 // Arguments returns the porklock settings needed for the input operation.
 func (i *StepInput) Arguments(username string, metadata []FileMetadata) []string {
-	path := i.IRODSPath()
 	args := []string{
 		"get",
 		"--user", username,
-		"--source", path,
+		"--source", i.IRODSPath(),
 	}
+
 	for _, m := range MetadataArgs(metadata).FileMetadataArguments() {
 		args = append(args, m)
 	}
+
 	return args
 }
 

--- a/vendor/gopkg.in/cyverse-de/model.v2/jobs.go
+++ b/vendor/gopkg.in/cyverse-de/model.v2/jobs.go
@@ -76,9 +76,10 @@ type Job struct {
 	FailureCount       int64          `json:"failure_count"`
 	FailureThreshold   int64          `json:"failure_threshold"`
 	FileMetadata       []FileMetadata `json:"file-metadata"`
-	FilterFiles        []string       `json:"filter_files"`       //comes from config, not upstream service
-	Group              string         `json:"group"`              //untested for now
-	InputTicketsFile   string         `json:"inputs_ticket_list"` //path to a list of inputs with tickets (not from upstream).
+	FilterFiles        []string       `json:"filter_files"`      //comes from config, not upstream service
+	Group              string         `json:"group"`             //untested for now
+	InputPathListFile  string         `json:"input_path_list"`   //path to a list of inputs (not from upstream).
+	InputTicketsFile   string         `json:"input_ticket_list"` //path to a list of inputs with tickets (not from upstream).
 	InvocationID       string         `json:"uuid"`
 	IRODSBase          string         `json:"irods_base"`
 	Name               string         `json:"name"`
@@ -376,6 +377,18 @@ func (s *Job) UsesVolumes() bool {
 	return false
 }
 
+// Returns a list of inputs that do not have download tickets.
+func (job *Job) FilterInputsWithoutTickets() []StepInput {
+	var inputs []StepInput
+	for _, input := range job.Inputs() {
+		if input.Ticket == "" {
+			inputs = append(inputs, input)
+		}
+	}
+	return inputs
+}
+
+// Returns a list of inputs that have download tickets.
 func (job *Job) FilterInputsWithTickets() []StepInput {
 	var inputs []StepInput
 	for _, input := range job.Inputs() {


### PR DESCRIPTION
This PR will update `JobCompose` and `JobRunner` to use a submitted `InputPathListFile` (added by cyverse-de/model#13) in order to download all inputs with 1 container, rather than downloading individual inputs each with their own container.

Input downloads will be much faster by using only 1 container to download all inputs.